### PR TITLE
fix: URL encode spaces in callback scope parameter

### DIFF
--- a/oauth2_cli_auth/code_grant.py
+++ b/oauth2_cli_auth/code_grant.py
@@ -82,7 +82,7 @@ def get_auth_url(client_info: OAuth2ClientInfo, redirect_uri: str) -> str:
     return (f"{client_info.authorization_url}"
             f"?client_id={client_info.client_id}"
             f"&redirect_uri={redirect_uri}"
-            f"&scope={' '.join(client_info.scopes)}"
+            f"&scope={'+'.join(client_info.scopes)}"
             f"&response_type=code")
 
 

--- a/oauth2_cli_auth/code_grant_test.py
+++ b/oauth2_cli_auth/code_grant_test.py
@@ -15,7 +15,7 @@ client_info = OAuth2ClientInfo(
 def test_get_auth_url():
     auth_url = get_auth_url(client_info, "http://localhost:123")
     assert auth_url == (
-        'https://auth.com/oauth/authorize?client_id=dummy&redirect_uri=http://localhost:123&scope=openid '
+        'https://auth.com/oauth/authorize?client_id=dummy&redirect_uri=http://localhost:123&scope=openid+'
         'profile&response_type=code'
     )
 


### PR DESCRIPTION
## Description

This PR updates `get_auth_url()` to use `+` instead of ` ` when joining the scopes passed into the callback URL query string to ensure they are encoded, and avoid issues when invoking custom xdg-open implementations, e.g.:

```
Open your browser at
https://myhost.net/oauth/authorize?client_id=xxxxx&redirect_uri=http://localhost:8080&scope=api read_api read_user k8s_proxy read_repository write_repository openid profile email&response_type=code
grep: read_api: No such file or directory
grep: read_user: No such file or directory
grep: k8s_proxy: No such file or directory
grep: read_repository: No such file or directory
grep: write_repository: No such file or directory
grep: openid: No such file or directory
grep: profile: No such file or directory
grep: email&response_type=code: No such file or directory
xdg-open: unexpected argument 'read_api'
Try 'xdg-open --help' for more information.
^C
Aborted!
```

FWIW: the real issue was in my custom `xdg-open` script which was missing quoting in a few places (fixed now).