### PR TITLE
fix: restore python 3.9 compatibility

### DIFF
--- a/oauth2_cli_auth/_urllib_util.py
+++ b/oauth2_cli_auth/_urllib_util.py
@@ -2,6 +2,7 @@ import json
 import time
 import urllib
 from urllib.error import URLError
+from typing import Union
 
 
 def _urlopen_with_backoff(url, max_retries=3, base_delay=1, timeout=15):
@@ -19,7 +20,7 @@ def _urlopen_with_backoff(url, max_retries=3, base_delay=1, timeout=15):
     raise URLError(f"Failed to open URL after {max_retries} retries")
 
 
-def _load_json(url_or_request: str | urllib.request.Request) -> dict:
+def _load_json(url_or_request: Union[str, urllib.request.Request]) -> dict:
     with _urlopen_with_backoff(url_or_request) as response:
         response_data = response.read().decode('utf-8')
         json_response = json.loads(response_data)

--- a/oauth2_cli_auth/code_grant.py
+++ b/oauth2_cli_auth/code_grant.py
@@ -7,6 +7,7 @@ import urllib.request
 import webbrowser
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Optional
 
 from oauth2_cli_auth._urllib_util import _load_json
 
@@ -58,7 +59,7 @@ def load_oidc_config(odic_well_known_endpoint: str) -> dict:
     return config
 
 
-def open_browser(url: str, print_open_browser_instruction: Callable[[str], None] | None = print) -> None:
+def open_browser(url: str, print_open_browser_instruction: Optional[Callable[[str], None]] = print) -> None:
     """
     Open browser using webbrowser module and show message about URL open
 

--- a/oauth2_cli_auth/http_server.py
+++ b/oauth2_cli_auth/http_server.py
@@ -234,9 +234,9 @@ class OAuthCallbackHttpServer(HTTPServer):
     def __init__(self, port):
         super().__init__(("", port), OAuthRedirectHandler)
 
-        self._code: str | None = None
+        self._code: Optional[str] = None
 
-    def get_code(self) -> str | None:
+    def get_code(self) -> Optional[str]:
         """
         This method should only be called after the request was done and might be None when no token is given.
 


### PR DESCRIPTION
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
#65 

## Description
<!-- Short description about the change, what have you done? -->

This PR restores python 3.9 compatibility:

```
# poetry run pytest
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.19, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/patrick/workspaces/python/python-oauth2-cli-auth
configfile: pyproject.toml
collected 10 items

oauth2_cli_auth/_timeout_test.py .                                                                                                                                                                            [ 10%]
oauth2_cli_auth/_urllib_util_test.py ..                                                                                                                                                                       [ 30%]
oauth2_cli_auth/code_grant_test.py ....                                                                                                                                                                       [ 70%]
oauth2_cli_auth/http_server_test.py ..                                                                                                                                                                        [ 90%]
oauth2_cli_auth/simplified_flow_test.py .                                                                                                                                                                     [100%]

================================================================================================ 10 passed in 3.04s =================================================================================================
```